### PR TITLE
Remove importação de Link do react-router-dom

### DIFF
--- a/src/components/molecules/NavBar/NavBar.js
+++ b/src/components/molecules/NavBar/NavBar.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import { Link } from "react-router-dom";
 import { FiMail, FiUsers, FiBell } from "react-icons/fi";
 
 import { Nav, Container, NavLinks, Flex, Name } from "./styles";


### PR DESCRIPTION
Essa importação que não é usada em lugar nenhum tava crasheando o build e não funcionava o styleguide